### PR TITLE
Be more liberal with dependency versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(name='django-yamlfield',
       data_files=data_files,
       include_package_data=True,
       install_requires=[
-        'PyYAML==3.10',
-        'six==1.4.1'
+        'PyYAML>=3.10',
+        'six>=1.4.1'
       ],
      )


### PR DESCRIPTION
Pinning PyYAML to 3.10 causes conflicts in projects that have dependencies that require 3.11 or newer.  Assuming that newer versions would work just as well, let's allow them.
